### PR TITLE
Add official translations section under ReadMe 

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -58,6 +58,16 @@ We have no aspiration to earn any financial return on any aspect of the project,
 
 We plan to pursue these approaches and to put any funds raised into the collective control of the community, after any necessary expenditures to ensure physical printing and distribution of the book are completed.  We understand this will require appropriate legal steps to ensure compliance with organizational forms and standard in relevant jurisdictions and we plan to undertake these in the coming months, possibly with the assistance of the Open Collective Foundation.
 
+# Official Active Translation Repositories
+
+We encourage different communities to help us translate the content in various languages for more accessibility around the world, anyone should feel free to fork the repository to initiate their translation work. We aim to allow communities to contribute in scalable and decentralized ways while granting official status upon approval. Please reach out to administrator of this repository to be recognized and added below as the official translation
+
+- German
+- Japanese
+- Traditional-Mandarin
+
+(liniks to be added)
+
 # Summary and next steps
 
 We look forward to collaborating with all of you on this exciting project.  Please reach out to glen@plurality.net if you have any questions that you cannot convey through our collaboration channels.

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -60,7 +60,7 @@ We plan to pursue these approaches and to put any funds raised into the collecti
 
 # Official Active Translation Repositories
 
-We encourage different communities to help us translate the content in various languages for more accessibility around the world, anyone should feel free to fork the repository to initiate their translation work. We aim to allow communities to contribute in scalable and decentralized ways while granting official status upon approval. Please reach out to administrator of this repository to be recognized and added below as the official translation
+We encourage different communities to help us translate the content in various languages for more accessibility around the world, anyone should feel free to fork the repository to initiate their translation work. We aim to allow communities to contribute in scalable and decentralized ways while granting official status upon approval. We hope to also add a simple guide on the best way to structure a translation fork. Please reach out to administrator of this repository to be recognized and added below as the official translation
 
 - German
 - Japanese

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -66,7 +66,7 @@ We encourage different communities to help us translate the content in various l
 - Japanese
 - Traditional-Mandarin
 
-(liniks to be added)
+(links to be added)
 
 # Summary and next steps
 


### PR DESCRIPTION
### Context 

Few communities have started translation work with different approaches, German team pivoted from branch to repository along with other translations (Japanese/Traditional Mandarin) thinking this might be the best way to scale. Expanded from this original [comment](https://github.com/pluralitybook/plurality/pull/6#issuecomment-1595052649):

The hope is we can 
- Standardize the translation workflow/structure to scale community contributions in decentralized ways while giving official recognition for legitimacy

Once there is a consensus on the best way between the initial communities, in the future we can 
- Make it simple for new languages to onboard with a suggested/tested framework to follow

With a similar structure of translated content for each repository, we could optimize to
- Automate updating the translation on the website directly from GitHub

### Description 

* This PR hopes to start the conversation between communities on if the above approach/direction makes sense 
* The PR adds a new section for recognized translations to demonstrate what the proposal here is suggesting
