### PR TITLE
Removes spam in 04-04

### DIFF
--- a/contents/english/04-04-property-and-contract.md
+++ b/contents/english/04-04-property-and-contract.md
@@ -1,33 +1,5 @@
 # Property and Contract
 
-Dear Vasana Gamers,
-
-Step into the Legend with "Yusha"!
-
-We're thrilled to introduce "Yusha", our latest gaming marvel, drawing inspiration from the iconic Dragon Quest series. Embrace the spirit of the cherished Dragon Quest adventures, where heroes vanquish fearsome foes and unravel the mysteries of enchanted realms. "Yusha", meaning "the brave one" in Japanese, elevates this timeless concept, blending it with cutting-edge technology for an unparalleled, real-world gaming odyssey.
-
-Epic Features of "Yusha":
-
-1. Power Up with Your Device: Unleash Your Hero's Potential: Tap into the power of your device to fuel your Yusha's adventures. By harnessing the computing power of your local device, you refill your Yusha’s energy bar. Your real-world tech usage recharges your hero, bridging your daily life with your in-game exploits.
-
-2. Explore to Expand: Your World, Your Battlefield : Venture into the real world to shape your virtual domain. As you explore new physical locations, your device captures the topography, transforming it into a dynamic, magical world within the game. This means your real-world adventures directly expand the game’s virtual territory, for all players.
-
-3. Treasure Hunts Redefined: Forge Connections, Discover Riches: "Yusha" introduces a novel twist to classic gaming mechanics by not randomly dispersing treasures throughout the game map. Instead, these treasures are hidden within the storage of the players' devices, and can only be discovered through engaging in social interactions with fellow players. These interactions vary widely and include activities like embarking on joint quests, healing a fellow player, crafting weapons for others, or simply engaging in conversation and listening to their stories. The method to unlock these treasures remains a mystery, not even known to the players themselves. The only way forward is to persist in fostering genuine connections with others, reflecting the cooperative essence reminiscent of the legendary Dragon Quest adventures.
-
-4. Guarded Realms: Your Privacy, Our Priority: Information regarding your device, location, and surroundings, along with your in-game actions, are thoroughly safeguarded by advanced privacy technologies. The enchanting realm of Yusha is crafted from the players' exploration of the real world. We employ artificial intelligence to transfigure these physical environments into resplendent mountains and gleaming golden cities, ensuring that your actual location remains confidential.
-
-5. Reality-Enhanced Gaming: Live the Adventure: “Yusha” is designed to augment your reality, not just serve as a virtual escape. Your dedication and exploration in the real world directly empower your Yusha and expand your virtual realm. True to the spirit of Dragon Quest, the treasures of our game lie in the connections you make and the adventures you embark upon, both virtually and physically.
-
-Join the ranks of Vasana's adventurers where fantasy and reality blend into an epic saga. When you invest not just your time, but also the computing resources of your device, the physical effort exerted in traversing the real world, and the genuine intent to forge authentic connections, the world of Yusha transforms into a realm that is profoundly immersive and interactive. This convergence of digital and physical efforts brings the game's environment to life, enriching the gaming experience with a unique depth and realism that encourages a deeper sense of engagement and community among players.
-
-Embark on the Adventure,
-The Vasana Team
-
----
-
-
-
-
 Most large-scale cooperation in ⿻ societies takes place through the pooling of assets into entities that are considered chartered as corporations, including limited liability partnerships, civic organizations, religious organizations, trade associations, unions, and, of course, for-profit stock corporations.  Their legal basis is in contractual arrangement that governs a sharing of assets (real, intellectual, human and financial) in a common undertaking towards a shared purpose.  Even the simplest, most common and smallest scale contracts, such as rental agreements, involve the sharing of assets across people.  
 
 A core aim of Lick's original vision for the "Intergalactic Computer Network" was to facilitate the sharing of digital assets, such as computation, storage and data.  And, in some ways, such sharing is the heart of today's digital economy, with "the Cloud" providing a vast pool of shared computation and storage and the wide range of information shared online forming the foundation of the generative foundation models (GFMs) that are sweeping the technology industry.  Yet for all the success of this work, it is confined to limited slices of the digital world and controlled by a small group of highly profitable, for-profit entities based in at most a handful of countries, creating both tremendous waste of opportunity and concentration of power.  The dream that the internet could enable broad and horizontal asset sharing has yet to be realized.


### PR DESCRIPTION
### Summary

This PR removes the "Vasana Gamers" section from 04-04: Property and Freedom.

### Motivation

The removed text appears to be spam as evidenced by a) a lack of bridging context with the rest of the text, and b) by its lack of presence in the Mandarin version.