### PR TITLE
fix(ci): configure GitHub Pages deployment environment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -239,9 +239,7 @@ jobs:
           EXPECTED_SOURCE_REVISION: ${{ github.sha }}
         run: vp run book:candidate:validate
 
-  # NOTE: The GitHub Pages build/deployment source must be switched from the legacy "gh-pages" branch
-  # to "GitHub Actions" in the repository settings ONLY after this workflow has run successfully and is green.
-  # DO NOT mutate live Pages settings or push directly.
+  # GitHub Pages is configured to deploy from GitHub Actions.
   deploy-pages:
     runs-on: ubuntu-latest
     needs: docs
@@ -249,6 +247,8 @@ jobs:
     permissions:
       pages: write
       id-token: write
+    environment:
+      name: github-pages
     steps:
       - name: Deploy to GitHub Pages
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e


### PR DESCRIPTION
Add the required github-pages environment to deploy-pages. The Pages API source is now configured as build_type=workflow, so the next push-to-main deployment can create the Pages deployment.